### PR TITLE
增加把iptables保存到文件的命令

### DIFF
--- a/docs/en_US/guide/pve_kvm.md
+++ b/docs/en_US/guide/pve_kvm.md
@@ -142,6 +142,7 @@ service networking restart
 systemctl restart networking.service
 systemctl restart ndpresponder.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 rm -rf vm102
 ```
 
@@ -188,6 +189,7 @@ service networking restart
 systemctl restart networking.service
 systemctl restart ndpresponder.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 rm -rf vmlog
 rm -rf vm*
 ```

--- a/docs/en_US/guide/pve_lxc.md
+++ b/docs/en_US/guide/pve_lxc.md
@@ -98,6 +98,7 @@ service networking restart
 systemctl restart networking.service
 systemctl restart ndpresponder.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 ```
 
 ## Batch Creation of LXC Containers with NAT
@@ -144,6 +145,7 @@ service networking restart
 systemctl restart networking.service
 systemctl restart ndpresponder.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 ```
 
 ## Creating Virtual Machines with Pure IPv6 Addresses

--- a/docs/en_US/guide/pve_qa.md
+++ b/docs/en_US/guide/pve_qa.md
@@ -53,6 +53,7 @@ iptables -t filter -F
 service networking restart
 systemctl restart networking.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 ```
 
 ## Verified VPS Providers

--- a/docs/guide/pve_kvm.md
+++ b/docs/guide/pve_kvm.md
@@ -159,6 +159,7 @@ service networking restart
 systemctl restart networking.service
 systemctl restart ndpresponder.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 rm -rf vm102
 ```
 
@@ -211,6 +212,7 @@ service networking restart
 systemctl restart networking.service
 systemctl restart ndpresponder.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 rm -rf vmlog
 rm -rf vm*
 ```

--- a/docs/guide/pve_lxc.md
+++ b/docs/guide/pve_lxc.md
@@ -104,6 +104,7 @@ service networking restart
 systemctl restart networking.service
 systemctl restart ndpresponder.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 ```
 
 ## 批量开设NAT的LXC虚拟化的CT
@@ -155,6 +156,7 @@ service networking restart
 systemctl restart networking.service
 systemctl restart ndpresponder.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 ```
 
 ## 开设纯IPV6地址的虚拟机

--- a/docs/guide/pve_qa.md
+++ b/docs/guide/pve_qa.md
@@ -53,6 +53,7 @@ iptables -t filter -F
 service networking restart
 systemctl restart networking.service
 iptables-save | awk '{if($1=="COMMIT"){delete x}}$1=="-A"?!x[$0]++:1' | iptables-restore
+iptables-save > /etc/iptables/rules.v4
 ```
 
 ## 目前已验证的VPS商家


### PR DESCRIPTION
实测进行删除小鸡等操作，并移除端口转发规则之后，需要将iptables改动写回文件，否则开机会复原（因为创建小鸡的时候写到文件了）。

另想咨询：在删除单个小鸡的部分，实际上会清除整个端口映射表，造成其他没有被删除的小鸡端口转发也失效。是否是错误？